### PR TITLE
Several updates

### DIFF
--- a/src/Control/Conditional.hs
+++ b/src/Control/Conditional.hs
@@ -44,8 +44,9 @@ module Control.Conditional
 import Data.Algebra.Boolean
 import Control.Monad hiding (guard, when, unless)
 import Control.Category 
-import Data.Monoid
 import Data.Maybe
+import Data.Monoid
+import Data.Ord (Down(..))
 import Prelude hiding ((.), id, (&&), (||), not)
 
 infixr  0 <|, |>, ⊳, ⊲, ?, <<|, |>>
@@ -65,10 +66,27 @@ infixr  9 ?.
 class ToBool bool where
   toBool :: bool -> Bool
 
-instance ToBool Bool where toBool = id
-instance ToBool Any  where toBool = getAny
-instance ToBool All  where toBool = getAll
-instance ToBool (Dual Bool) where toBool = getDual
+instance ToBool Bool where
+  toBool = id
+
+instance ToBool Any  where
+  toBool = getAny
+  
+instance ToBool All  where
+  toBool = getAll
+
+instance ToBool a => ToBool (Dual a) where
+  toBool = toBool . getDual
+
+instance ToBool a => ToBool (AnyB a) where
+  toBool = toBool . getAnyB
+
+instance ToBool a => ToBool (AllB a) where
+  toBool = toBool . getAllB
+
+instance ToBool a => ToBool (Down a) where
+  toBool = not . toBool . getDown
+
 
 -- |A simple conditional operator
 if' :: ToBool bool => bool -> a -> a -> a

--- a/src/Data/Algebra/Boolean.hs
+++ b/src/Data/Algebra/Boolean.hs
@@ -61,17 +61,17 @@ class Boolean b where
   nand :: Foldable t => t b -> b
   nand = not . and
 
-  -- | The logical conjunction of the mapping of a function over several values.
-  all :: Foldable t => (a -> b) -> t a -> b
-
-  -- | The logical disjunction of the mapping of a function over several values.
-  any :: Foldable t => (a -> b) -> t a -> b
-
   -- | The negated logical disjunction of several values.
   --
   -- @'nor' = 'not' . 'or'@
   nor :: Foldable t => t b -> b
   nor = not . or
+
+  -- | The logical conjunction of the mapping of a function over several values.
+  all :: Foldable t => (a -> b) -> t a -> b
+
+  -- | The logical disjunction of the mapping of a function over several values.
+  any :: Foldable t => (a -> b) -> t a -> b
 
   {-# MINIMAL (false | true), (not | ((<-->), false)), ((||) | (&&)) #-}
 

--- a/src/Data/Algebra/Boolean.hs
+++ b/src/Data/Algebra/Boolean.hs
@@ -129,16 +129,6 @@ instance Boolean (Dual Bool) where
   (Dual p) --> (Dual q)   = Dual (p --> q)
   (Dual p) <--> (Dual q)  = Dual (p <--> q)
 
-instance Boolean (Endo Bool) where
-  true                    = Endo (const True)
-  false                   = Endo (const False)
-  not (Endo p)            = Endo (not . p)
-  (Endo p) && (Endo q)    = Endo (\a -> p a && q a)
-  (Endo p) || (Endo q)    = Endo (\a -> p a || q a)
-  (Endo p) `xor` (Endo q) = Endo (\a -> p a `xor` q a)
-  (Endo p) --> (Endo q)   = Endo (\a -> p a --> q a)
-  (Endo p) <--> (Endo q)  = Endo (\a -> p a <--> q a)
-
 -- | Pointwise boolean algebra.
 --
 instance Boolean b => Boolean (a -> b) where
@@ -150,6 +140,16 @@ instance Boolean b => Boolean (a -> b) where
   p `xor` q = \a -> p a `xor` q a
   p --> q   = \a -> p a --> q a
   p <--> q  = \a -> p a <--> q a
+
+instance Boolean a => Boolean (Endo a) where
+  true                    = Endo (const true)
+  false                   = Endo (const false)
+  not (Endo p)            = Endo (not . p)
+  (Endo p) && (Endo q)    = Endo (\a -> p a && q a)
+  (Endo p) || (Endo q)    = Endo (\a -> p a || q a)
+  (Endo p) `xor` (Endo q) = Endo (\a -> p a `xor` q a)
+  (Endo p) --> (Endo q)   = Endo (\a -> p a --> q a)
+  (Endo p) <--> (Endo q)  = Endo (\a -> p a <--> q a)
 
 instance (Boolean x, Boolean y) => Boolean (x, y) where
   true                = (true, true)

--- a/src/Data/Algebra/Boolean.hs
+++ b/src/Data/Algebra/Boolean.hs
@@ -35,7 +35,7 @@ infixr  2 ||
 infixr  3 &&
 
 -- |A class for boolean algebras. Instances of this class are expected to obey
--- all the laws of boolean algebra.
+-- all the laws of [boolean algebra](https://en.wikipedia.org/wiki/Boolean_algebra_(structure)).
 --
 -- Minimal complete definition: 'true' or 'false', 'not' or ('<-->', 'false'), '||' or '&&'.
 class Boolean b where

--- a/src/Data/Algebra/Boolean.hs
+++ b/src/Data/Algebra/Boolean.hs
@@ -95,9 +95,8 @@ instance Boolean Bool where
   (||) = (P.||)
   not = P.not
   xor = (/=)
-  True  --> True  = True
-  True  --> False = False
-  False --> _     = True
+  True  --> a = a
+  False --> _ = True
   (<-->) = (==)
 
 instance Boolean Any where

--- a/src/Data/Algebra/Boolean.hs
+++ b/src/Data/Algebra/Boolean.hs
@@ -182,4 +182,4 @@ instance (Num a, Bits a) => Boolean (Bitwise a) where
   (&&)   = (Bitwise .) . (.&.) `on` getBits
   (||)   = (Bitwise .) . (.|.) `on` getBits
   xor    = (Bitwise .) . (Bits.xor `on` getBits)
-  (<-->) = xor `on` not
+  (<-->) = (not .) . xor

--- a/src/Data/Algebra/Boolean.hs
+++ b/src/Data/Algebra/Boolean.hs
@@ -189,6 +189,17 @@ instance (Boolean x, Boolean y) => Boolean (x, y) where
   (a, b) --> (c, d)   = (a --> c, b --> d)
   (a, b) <--> (c, d)  = (a <--> c, b <--> d)
 
+instance (Boolean x, Boolean y, Boolean z) => Boolean (x, y, z) where
+  true                      = (true, true, true)
+  false                     = (false, false, false)
+  not (a, b, c)             = (not a, not b, not c)
+  (a, b, c) && (d, e, f)    = (a && d, b && e, c && f)
+  (a, b, c) || (d, e, f)    = (a || d, b || e, c || f)
+  (a, b, c) `xor` (d, e, f) = (a `xor` d, b `xor` e, c `xor` f)
+  (a, b, c) --> (d, e, f)   = (a --> d, b --> e, c --> f)
+  (a, b, c) <--> (d, e, f)  = (a <--> d, b <--> e, c <--> f)
+
+
 -- |A newtype wrapper that derives a 'Boolean' instance from any type that is both
 -- a 'Bits' instance and a 'Num' instance,
 -- such that boolean logic operations on the 'Bitwise' wrapper correspond to

--- a/src/Data/Algebra/Boolean.hs
+++ b/src/Data/Algebra/Boolean.hs
@@ -151,6 +151,16 @@ instance Boolean a => Boolean (Endo a) where
   (Endo p) --> (Endo q)   = Endo (\a -> p a --> q a)
   (Endo p) <--> (Endo q)  = Endo (\a -> p a <--> q a)
 
+-- |The trivial boolean algebra
+instance Boolean () where
+  true = ()
+  false = ()
+  not _ = ()
+  _ && _ = ()
+  _ || _ = ()
+  _ --> _ = ()
+  _ <--> _ = ()
+
 instance (Boolean x, Boolean y) => Boolean (x, y) where
   true                = (true, true)
   false               = (false, false)

--- a/src/Data/Algebra/Boolean.hs
+++ b/src/Data/Algebra/Boolean.hs
@@ -33,7 +33,7 @@ class Boolean b where
   false   :: b
   -- |Logical negation.
   not     :: b -> b
-  -- |Logical conjunction. (infxr 3)
+  -- |Logical conjunction. (infixr 3)
   (&&)    :: b -> b -> b
   -- |Logical inclusive disjunction. (infixr 2)
   (||)    :: b -> b -> b

--- a/src/Data/Algebra/Boolean.hs
+++ b/src/Data/Algebra/Boolean.hs
@@ -11,7 +11,6 @@ import Data.Function (on)
 import Data.Typeable
 import Data.Data
 import Data.Ix
-import Data.Foldable (Foldable)
 import qualified Data.Foldable as F
 import Foreign.Storable
 import Text.Printf

--- a/src/Data/Algebra/Boolean.hs
+++ b/src/Data/Algebra/Boolean.hs
@@ -30,7 +30,7 @@ infixr  3 &&
 -- |A class for boolean algebras. Instances of this class are expected to obey
 -- all the laws of boolean algebra.
 --
--- Minimal complete definition: 'true' or 'false', 'not' or '<-->', '||' or '&&'.
+-- Minimal complete definition: 'true' or 'false', 'not' or ('<-->', 'false'), '||' or '&&'.
 class Boolean b where
   -- |Truth value, defined as the top of the bounded lattice
   true    :: b
@@ -73,12 +73,14 @@ class Boolean b where
   nor :: Foldable t => t b -> b
   nor = not . or
 
+  {-# MINIMAL (false | true), (not | ((<-->), false)), ((||) | (&&)) #-}
+
   -- Default implementations
   true      = not false
   false     = not true
   not       = (<--> false)
-  x && y = not (not x || not y)
-  x || y = not (not x && not y)
+  x && y    = not (not x || not y)
+  x || y    = not (not x && not y)
   x `xor` y = (x || y) && (not (x && y))
   x --> y   = not x || y
   x <--> y  = (x && y) || not (x || y)


### PR DESCRIPTION
This pull request contains twelve commits, most of which are likely uncontroversial (corrections, extra instances, a MINIMAL pragma, removing unused imports).

The most controversial is likely to be 42f480f5, which removes the various instances which use Foldable out of the typeclass. I doubt anyone would want to redefine them anyway! The advantage of doing so is that many of the instances then become derivable, which removes boilerplate from the codebase. Since it's a breaking change, this would require a change of version number to 0.5.